### PR TITLE
Add hello/0 function to SymphonyElixir module

### DIFF
--- a/elixir/lib/symphony_elixir.ex
+++ b/elixir/lib/symphony_elixir.ex
@@ -4,6 +4,12 @@ defmodule SymphonyElixir do
   """
 
   @doc """
+  Return a greeting string from the Symphony orchestrator.
+  """
+  @spec hello() :: String.t()
+  def hello, do: "Hello from Symphony!"
+
+  @doc """
   Start the orchestrator in the current BEAM node.
   """
   @spec start_link(keyword()) :: GenServer.on_start()

--- a/elixir/test/symphony_elixir/core_test.exs
+++ b/elixir/test/symphony_elixir/core_test.exs
@@ -1,6 +1,10 @@
 defmodule SymphonyElixir.CoreTest do
   use SymphonyElixir.TestSupport
 
+  test "hello/0 returns greeting" do
+    assert SymphonyElixir.hello() == "Hello from Symphony!"
+  end
+
   test "config defaults and validation checks" do
     write_workflow_file!(Workflow.workflow_file_path(),
       tracker_api_token: nil,


### PR DESCRIPTION
#### Context

Smoke-test change to verify the Symphony orchestrator pipeline works end-to-end. Closes #7.

#### TL;DR

*Adds a `hello/0` greeting function to the `SymphonyElixir` module with spec, doc, and test.*

#### Summary

- Add `SymphonyElixir.hello/0` returning `"Hello from Symphony!"`
- Add `@spec` and `@doc` for the new function
- Add test in `core_test.exs` verifying the return value

#### Alternatives

- Could have added a no-op change (docs only), but a small function+test provides a concrete verification signal.

#### Test Plan

- [x] `make -C elixir all`
- [x] `mix test test/symphony_elixir/core_test.exs` — 37 tests, 0 failures